### PR TITLE
feat(wallet): disable tx submitting for read-only wallets

### DIFF
--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -8,6 +8,7 @@ export const contracts = checkContracts([
   {
     name: 'sovrynProtocol',
     address: {
+      30: '0x5A0D867e0D70Fcc6Ade25C3F1B89d618b5B4Eaa7',
       31: '0x25380305f223B32FDB844152abD2E82BC5Ad99c3',
     },
   },
@@ -21,24 +22,21 @@ export const contracts = checkContracts([
   {
     name: 'priceFeeds',
     address: {
+      30: '0x437AC62769f386b2d238409B7f0a7596d36506e4',
       31: '0x7f38c422b99075f63C9c919ECD200DF8d2Cf5BD4',
-    },
-  },
-  {
-    name: 'protocolSettings',
-    address: {
-      31: '0xa29CCeD858D46a0F91CC48646fa849D47eC96090',
     },
   },
   {
     name: 'rbtcWrapper',
     address: {
+      30: '0xa917BF723433d020a15629eba71f6C2a6B38e52d',
       31: '0x6b1a4735b1e25cce9406b2d5d7417ce53d1cf90e',
     },
   },
   {
     name: 'swapNetwork',
     address: {
+      30: '0x98aCE08D2b759a265ae326F010496bcD63C15afc',
       31: '0x61172B53423E205a399640e5283e51FE60EC2256',
     },
   },

--- a/src/pages/SwapPage/screens/SwapIndexScreen.tsx
+++ b/src/pages/SwapPage/screens/SwapIndexScreen.tsx
@@ -23,6 +23,7 @@ import { ContractName } from 'types/contract';
 import { useAssetBalance } from 'hooks/useAssetBalance';
 import { Button, ButtonIntent } from 'components/Buttons/Button';
 import { transactionController } from 'controllers/TransactionController';
+import { ReadWalletAwareWrapper } from 'components/ReadWalletAwareWapper';
 
 type Props = NativeStackScreenProps<SwapStackProps, 'swap.index'>;
 
@@ -262,18 +263,20 @@ export const SwapIndexScreen: React.FC<Props> = () => {
               debounceDelay={0}
             />
           </View>
-          <TokenApprovalFlow
-            tokenId={sendTokenId}
-            spender={callData.contractAddress}
-            requiredAmount={sendAmount || '0'}>
-            <Button
-              title="Swap"
-              onPress={handleSwapButton}
-              disabled={loading}
-              loading={loading}
-              intent={ButtonIntent.PRIMARY}
-            />
-          </TokenApprovalFlow>
+          <ReadWalletAwareWrapper>
+            <TokenApprovalFlow
+              tokenId={sendTokenId}
+              spender={callData.contractAddress}
+              requiredAmount={sendAmount || '0'}>
+              <Button
+                title="Swap"
+                onPress={handleSwapButton}
+                disabled={loading}
+                loading={loading}
+                intent={ButtonIntent.PRIMARY}
+              />
+            </TokenApprovalFlow>
+          </ReadWalletAwareWrapper>
           <View>
             <View>
               <Text>Sell Price</Text>

--- a/src/pages/WalletScreen/SendAsset.tsx
+++ b/src/pages/WalletScreen/SendAsset.tsx
@@ -22,10 +22,11 @@ import { SafeAreaPage } from 'templates/SafeAreaPage';
 import { Text } from 'components/Text';
 import { transactionController } from 'controllers/TransactionController';
 import { Button, ButtonIntent } from 'components/Buttons/Button';
+import { useDebouncedEffect } from 'hooks/useDebounceEffect';
+import { ReadWalletAwareWrapper } from 'components/ReadWalletAwareWapper';
 
 type Props = NativeStackScreenProps<WalletStackProps, 'wallet.receive'>;
 
-// TODO: implement debouncing
 export const SendAsset: React.FC<Props> = ({
   route: { params },
   navigation,
@@ -57,50 +58,66 @@ export const SendAsset: React.FC<Props> = ({
 
   const owner = useWalletAddress();
 
-  useEffect(() => {
-    getProvider(params.chainId)
-      .getTransactionCount(owner)
-      .then(response => setNonce(response.toString()));
-  }, [owner, params.chainId]);
+  useDebouncedEffect(
+    () => {
+      getProvider(params.chainId)
+        .getTransactionCount(owner)
+        .then(response => setNonce(response.toString()));
+    },
+    300,
+    [owner, params.chainId],
+  );
 
   const handleReceiverChange = useCallback(
     (address: string) => setReceiver(address),
     [],
   );
 
-  useEffect(() => {
-    getProvider(params.chainId)
-      .getGasPrice()
-      .then(response => setGasPrice((response.toNumber() / 1e9).toString()));
-  }, [params.chainId]);
+  useDebouncedEffect(
+    () => {
+      getProvider(params.chainId)
+        .getGasPrice()
+        .then(response => setGasPrice((response.toNumber() / 1e9).toString()));
+    },
+    300,
+    [params.chainId],
+  );
 
-  useEffect(() => {
-    if (!params.token.native) {
-      setData(
-        encodeFunctionData('transfer(address,uint256)', [
-          (receiver || constants.AddressZero).toLowerCase(),
-          utils.parseUnits(amount || '0', params.token.decimals).toString(),
-        ]),
-      );
-    }
-  }, [receiver, amount, params.token]);
+  useDebouncedEffect(
+    () => {
+      if (!params.token.native) {
+        setData(
+          encodeFunctionData('transfer(address,uint256)', [
+            (receiver || constants.AddressZero).toLowerCase(),
+            utils.parseUnits(amount || '0', params.token.decimals).toString(),
+          ]),
+        );
+      }
+    },
+    300,
+    [receiver, amount, params.token],
+  );
 
-  useEffect(() => {
-    getProvider(params.chainId)
-      .estimateGas({
-        to,
-        value: params.token.native
-          ? utils.parseUnits(amount || '0', params.token.decimals)
-          : 0,
-        nonce,
-        data,
-        gasPrice: (Number(gasPrice) * 1e9).toString(),
-      })
-      .then(response => response.toNumber())
-      .then(response => {
-        setGas(!response ? '21000' : response.toString());
-      });
-  }, [params.chainId, params.token, gasPrice, data, nonce, to, amount]);
+  useDebouncedEffect(
+    () => {
+      getProvider(params.chainId)
+        .estimateGas({
+          to,
+          value: params.token.native
+            ? utils.parseUnits(amount || '0', params.token.decimals)
+            : 0,
+          nonce,
+          data,
+          gasPrice: (Number(gasPrice) * 1e9).toString(),
+        })
+        .then(response => response.toNumber())
+        .then(response => {
+          setGas(!response ? '21000' : response.toString());
+        });
+    },
+    300,
+    [params.chainId, params.token, gasPrice, data, nonce, to, amount],
+  );
 
   const submit = useCallback(async () => {
     setLoading(true);
@@ -211,13 +228,15 @@ export const SendAsset: React.FC<Props> = ({
                 fee={params.token.native ? Number(fee) : 0}
               />
               {!!balanceError && <Text>{balanceError}</Text>}
-              <Button
-                title={`Send ${params.token.symbol}`}
-                onPress={submit}
-                disabled={!isTxValid || loading}
-                loading={loading}
-                intent={ButtonIntent.PRIMARY}
-              />
+              <ReadWalletAwareWrapper>
+                <Button
+                  title={`Send ${params.token.symbol}`}
+                  onPress={submit}
+                  disabled={!isTxValid || loading}
+                  loading={loading}
+                  intent={ButtonIntent.PRIMARY}
+                />
+              </ReadWalletAwareWrapper>
             </View>
           </TouchableWithoutFeedback>
         </KeyboardAvoidingView>


### PR DESCRIPTION
- disable submit button for read-only wallets in send asset screen
- disable submit button for read-only wallets in swap assets screen
- added mainnet smart-contracts
- switched useEffect with useDebouncedEffect  for send asset screen