### PR TITLE
feat(passcode): allow users to change their app passcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ List of planned and available features:
 - [x] List supported assets and balances
 - [x] Send any asset to other wallets (addresses)
 - [x] Vested assets (list)
-- [ ] Vested assets (withdraw unlocked)
+- [x] Vested assets (withdraw unlocked)
 - [ ] Lending
 - [ ] Liquidity mining
 - [ ] Borrowing

--- a/src/components/NavGroup/NavItem.tsx
+++ b/src/components/NavGroup/NavItem.tsx
@@ -15,7 +15,7 @@ export type NavItemProps = {
   hideArrow?: boolean;
   isFirst?: boolean;
   isLast?: boolean;
-  value?: string | number;
+  value?: React.ReactNode;
   danger?: boolean;
 };
 
@@ -40,6 +40,16 @@ export const NavItem: React.FC<NavItemProps> = ({
     [danger],
   );
 
+  const renderValue = useMemo(() => {
+    if (!value) {
+      return null;
+    }
+    if (typeof value === 'string' || typeof value === 'number') {
+      return <Text style={styles.rightContainerText}>{value}</Text>;
+    }
+    return value;
+  }, [value, styles]);
+
   return (
     <Pressable
       style={[
@@ -56,7 +66,7 @@ export const NavItem: React.FC<NavItemProps> = ({
         <Text>{title}</Text>
       </View>
       <View style={styles.rightContainer}>
-        {value && <Text style={styles.rightContainerText}>{value}</Text>}
+        {renderValue}
         {!hideArrow && (
           <ChevronRight
             fill={pressedIn ? DarkTheme.colors.card : DarkTheme.colors.border}

--- a/src/controllers/PassCodeController.ts
+++ b/src/controllers/PassCodeController.ts
@@ -39,9 +39,12 @@ class PassCodeController {
 
   protected _unlocked: boolean = false;
 
-  public async request(title?: string): Promise<string> {
+  public async request(
+    title?: string,
+    skipBiometrics: boolean = false,
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
-      this.hub.emit('request', { resolve, reject, title });
+      this.hub.emit('request', { resolve, reject, title, skipBiometrics });
     });
   }
 
@@ -96,7 +99,7 @@ class PassCodeController {
   ): Promise<string | false> {
     const type = await this.getPasscodeType();
 
-    if (!type) {
+    if (!type || type === PassCodeType.PASSCODE) {
       return Promise.resolve(false);
     }
 

--- a/src/hooks/useBiometryType.ts
+++ b/src/hooks/useBiometryType.ts
@@ -1,8 +1,10 @@
 import { passcode } from 'controllers/PassCodeController';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { BIOMETRY_TYPE } from 'react-native-keychain';
 
-const cache: { value: BIOMETRY_TYPE | null } = { value: null };
+const cache: { value: BIOMETRY_TYPE | null } = {
+  value: null,
+};
 
 export function useBiometryType(): BIOMETRY_TYPE | null {
   const [value, setValue] = useState<BIOMETRY_TYPE | null>(cache.value);
@@ -18,4 +20,26 @@ export function useBiometryType(): BIOMETRY_TYPE | null {
   }, []);
 
   return value;
+}
+
+export function usePrettyBiometryName(): string | null {
+  const type = useBiometryType();
+  const name = useMemo(() => {
+    switch (type) {
+      case BIOMETRY_TYPE.FACE_ID:
+        return 'Face ID';
+      case BIOMETRY_TYPE.FACE:
+        return 'Face Recognition';
+      case BIOMETRY_TYPE.TOUCH_ID:
+        return 'Touch ID';
+      case BIOMETRY_TYPE.FINGERPRINT:
+        return 'Fingerprints';
+      case BIOMETRY_TYPE.IRIS:
+        return 'Iris';
+      default:
+        return null;
+    }
+  }, [type]);
+
+  return name;
 }

--- a/src/pages/MainScreen/SettingsPage.tsx
+++ b/src/pages/MainScreen/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { WalletPrivateKey } from 'pages/SettingsScreen/WalletPrivateKey';
 import { WalletRecoveryPhrase } from 'pages/SettingsScreen/WalletRecoveryPhrase';
 import { SettingsPasscode } from 'pages/SettingsScreen/SettingsPasscode';
 import { SettingsAppearance } from 'pages/SettingsScreen/SettingsAppearance';
+import { SettingsPasscodeChange } from 'pages/SettingsScreen/SettingsPasscodeChange';
 
 type AccountProps = {
   index: number;
@@ -28,7 +29,8 @@ export type SettingsStackProps = {
   'settings.wallet.recovery-phrase': AccountProps;
   'settings.create': undefined;
   'settings.appearance': undefined;
-  'settings.passcode': undefined;
+  'settings.passcode': { password: string };
+  'settings.passcode.change': { password: string };
 };
 
 const Stack = createNativeStackNavigator<SettingsStackProps>();
@@ -50,6 +52,11 @@ export const SettingsPage: React.FC = () => {
         name="settings.passcode"
         component={SettingsPasscode}
         options={{ title: 'Passcode' }}
+      />
+      <Stack.Screen
+        name="settings.passcode.change"
+        component={SettingsPasscodeChange}
+        options={{ title: 'Change Passcode' }}
       />
       <Stack.Screen
         name="settings.appearance"

--- a/src/pages/SettingsScreen/SettingsPasscode.tsx
+++ b/src/pages/SettingsScreen/SettingsPasscode.tsx
@@ -1,18 +1,91 @@
-import React from 'react';
-import { ScrollView } from 'react-native';
-import { SafeAreaPage } from 'templates/SafeAreaPage';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { SettingsStackProps } from 'pages/MainScreen/SettingsPage';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { SafeAreaPage } from 'templates/SafeAreaPage';
+import { ScrollView, Switch } from 'react-native';
 import { globalStyles } from 'global.styles';
-import { Text } from 'components/Text';
+import { NavGroup } from 'components/NavGroup/NavGroup';
+import { NavItem } from 'components/NavGroup/NavItem';
+import { usePrettyBiometryName } from 'hooks/useBiometryType';
+import { passcode, PassCodeType } from 'controllers/PassCodeController';
+import { useFocusEffect } from '@react-navigation/native';
 
 type Props = NativeStackScreenProps<SettingsStackProps, 'settings.passcode'>;
 
-export const SettingsPasscode: React.FC<Props> = () => {
+export const SettingsPasscode: React.FC<Props> = ({
+  route: { params },
+  navigation,
+}) => {
+  const biometry = usePrettyBiometryName();
+  const [biometryEnabled, setBiometryEnabled] = useState(false);
+  const unfocusRef = useRef(false);
+
+  // redirect user out of this screen in case user was in another tab
+  // this will add some extra security and will not allow user to change
+  //   password without entering current one again
+  useFocusEffect(
+    useCallback(() => {
+      if (unfocusRef.current) {
+        navigation.reset({
+          index: 0,
+          routes: [{ name: 'settings.index' }],
+        });
+      }
+      return () => {
+        unfocusRef.current = true;
+      };
+    }, [navigation]),
+  );
+
+  useEffect(() => {
+    passcode
+      .getPasscodeType()
+      .then(type => setBiometryEnabled(type === PassCodeType.BIOMETRY))
+      .catch(() => setBiometryEnabled(false));
+  }, []);
+
+  const handleChangeClick = useCallback(
+    () =>
+      navigation.navigate('settings.passcode.change', {
+        password: params.password,
+      }),
+    [navigation, params.password],
+  );
+
+  const handleBiometryState = useCallback(async () => {
+    const verified = await passcode.verify(params.password);
+    if (verified) {
+      const type = await passcode.getPasscodeType();
+      await passcode.setPassword(
+        params.password,
+        type === PassCodeType.BIOMETRY
+          ? PassCodeType.PASSCODE
+          : PassCodeType.BIOMETRY,
+      );
+      setBiometryEnabled(type === PassCodeType.PASSCODE);
+    }
+  }, [params.password]);
+
   return (
     <SafeAreaPage>
       <ScrollView style={globalStyles.page}>
-        <Text>todo.</Text>
+        <NavGroup>
+          <NavItem title="Change passcode" onPress={handleChangeClick} />
+        </NavGroup>
+        {biometry && (
+          <NavGroup>
+            <NavItem
+              title={`Unlock with ${biometry}`}
+              hideArrow
+              value={
+                <Switch
+                  value={biometryEnabled}
+                  onValueChange={handleBiometryState}
+                />
+              }
+            />
+          </NavGroup>
+        )}
       </ScrollView>
     </SafeAreaPage>
   );

--- a/src/pages/SettingsScreen/SettingsPasscodeChange.tsx
+++ b/src/pages/SettingsScreen/SettingsPasscodeChange.tsx
@@ -1,0 +1,45 @@
+import React, { useCallback, useRef } from 'react';
+import { SettingsStackProps } from 'pages/MainScreen/SettingsPage';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { PassCodeSetup } from 'components/PassCode/PassCodeSetup';
+import { useFocusEffect } from '@react-navigation/native';
+import { accounts } from 'utils/accounts';
+
+type Props = NativeStackScreenProps<SettingsStackProps, 'settings.passcode'>;
+
+export const SettingsPasscodeChange: React.FC<Props> = ({
+  route: { params },
+  navigation,
+}) => {
+  const unfocusRef = useRef(false);
+
+  // redirect user out of this screen in case user was in another tab
+  // this will add some extra security and will not allow user to change
+  //   password without entering current one again
+  useFocusEffect(
+    useCallback(() => {
+      if (unfocusRef.current) {
+        navigation.reset({
+          index: 0,
+          routes: [{ name: 'settings.index' }],
+        });
+      }
+      return () => {
+        unfocusRef.current = true;
+      };
+    }, [navigation]),
+  );
+
+  const handleConfirm = useCallback(
+    async (newPassword: string) => {
+      await accounts.changePassword(params.password, newPassword);
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'settings.index' }],
+      });
+    },
+    [navigation, params.password],
+  );
+
+  return <PassCodeSetup onPasscodeConfirmed={handleConfirm} />;
+};

--- a/src/pages/SettingsScreen/WalletDerivationPath.tsx
+++ b/src/pages/SettingsScreen/WalletDerivationPath.tsx
@@ -1,12 +1,5 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
-import { Alert, ScrollView, View } from 'react-native';
-import { AppContext } from 'context/AppContext';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ScrollView, View } from 'react-native';
 import { SafeAreaPage } from 'templates/SafeAreaPage';
 import { SettingsStackProps } from 'pages/MainScreen/SettingsPage';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -15,7 +8,6 @@ import { NavItem } from 'components/NavGroup/NavItem';
 import { globalStyles } from 'global.styles';
 import { Text } from 'components/Text';
 import { accounts, AccountType } from 'utils/accounts';
-import { passcode } from 'controllers/PassCodeController';
 import { makeWalletPrivateKey, wallet } from 'utils/wallet';
 import { Wallet } from 'ethers';
 import { currentChainId } from 'utils/helpers';
@@ -64,14 +56,6 @@ export const WalletDerivationPath: React.FC<Props> = ({
         console.log(e);
       });
   }, [password, account.secret]);
-
-  // const account = accounts.get(params.index);
-  // navigation.setOptions({ title: account.name });
-
-  // const activate = useCallback(
-  //   () => accounts.select(params.index),
-  //   [params.index],
-  // );
 
   const wallets = useMemo(() => {
     if (!masterSeed) {

--- a/src/utils/accounts.ts
+++ b/src/utils/accounts.ts
@@ -169,6 +169,20 @@ class AccountManager extends EventEmitter {
     this.onLoaded();
     this.onSelected();
   }
+  public async changePassword(currentPassword: string, newPassword: string) {
+    const items: Account[] = [];
+    for (let account of this._accounts) {
+      const decrypted = await this._encryptor.decrypt(
+        currentPassword,
+        account.secret!,
+      );
+      const encrypted = await this._encryptor.encrypt(newPassword, decrypted);
+      items.push({ ...account, secret: encrypted });
+    }
+    this._accounts = items;
+    await this.save();
+    this.onLoaded();
+  }
   protected async save() {
     await EncryptedStorage.setItem(
       'account_list',


### PR DESCRIPTION
- add: possibility to change passcode (decrypts all wallet secrets with old password and encrypts them back with new one)
- add: possibility to enable / disable biometrics
- add: delete entire data from app (account private keys, recovery phrases, passcodes and so on)
- add: allow NavItem to use ReactNode as value instead of only Text (fallbacks to Text)
- add: possibility to only authorise using passcode and skip biometrics even if it's enabled (for passcode change routes for example)
- fix: show biometrics name instead of constant id.
- fix: do not ask for biometrics if user skipped biometric setup
- fix: custom titles for passcode requests

Closes #29 